### PR TITLE
Displays description on validation warnings/errors

### DIFF
--- a/__tests__/index.test.ts
+++ b/__tests__/index.test.ts
@@ -150,7 +150,9 @@ describe('validateEnvVars', () => {
 
 	it('descriptions are logged on console warning', () => {
 		const schema = z.object({
-			OPTIONAL_1: z.string({description: 'This is an optional variable'}).optional(),
+			OPTIONAL_1: z
+				.string({ description: 'This is an optional variable' })
+				.optional(),
 			EXPECTED_2: z.string(),
 		});
 		const envPath = './__tests__/.env.test';
@@ -160,11 +162,11 @@ describe('validateEnvVars', () => {
 		expect(consoleLogSpy).toHaveBeenCalledTimes(3);
 		expect(consoleLogSpy).toHaveBeenNthCalledWith(
 			1,
-			expect.stringContaining("This is an optional variable")
+			expect.stringContaining('This is an optional variable')
 		);
 		expect(consoleLogSpy).toHaveBeenNthCalledWith(
 			2,
-			expect.not.stringContaining("This is an optional variable")
+			expect.not.stringContaining('This is an optional variable')
 		);
 	});
 });

--- a/__tests__/index.test.ts
+++ b/__tests__/index.test.ts
@@ -12,9 +12,11 @@ jest.mock('../src/validateInput');
 describe('validateEnvVars', () => {
 	let processExitSpy: jest.SpyInstance;
 	let consoleErrorSpy: jest.SpyInstance;
+	let consoleLogSpy: jest.SpyInstance;
 
 	beforeEach(() => {
 		consoleErrorSpy = jest.spyOn(console, 'error').mockImplementation();
+		consoleLogSpy = jest.spyOn(console, 'log').mockImplementation();
 		processExitSpy = jest.spyOn(process, 'exit').mockImplementation();
 	});
 
@@ -144,5 +146,25 @@ describe('validateEnvVars', () => {
 		expect(() => {
 			validateEnvVars({ schema, envPath });
 		}).not.toThrow();
+	});
+
+	it('descriptions are logged on console warning', () => {
+		const schema = z.object({
+			OPTIONAL_1: z.string({description: 'This is an optional variable'}).optional(),
+			EXPECTED_2: z.string(),
+		});
+		const envPath = './__tests__/.env.test';
+
+		validateEnvVars({ schema, envPath });
+
+		expect(consoleLogSpy).toHaveBeenCalledTimes(3);
+		expect(consoleLogSpy).toHaveBeenNthCalledWith(
+			1,
+			expect.stringContaining("This is an optional variable")
+		);
+		expect(consoleLogSpy).toHaveBeenNthCalledWith(
+			2,
+			expect.not.stringContaining("This is an optional variable")
+		);
 	});
 });

--- a/src/logParseResults.ts
+++ b/src/logParseResults.ts
@@ -62,6 +62,11 @@ function logParseResults(
 
 	// loop over each variable and log the result
 	Object.entries(schemaKeys).forEach(([varName, res]) => {
+		// Try to get the description from the Zod option if present
+		let description = '';
+		if (typeof schema.shape[varName]?.description === 'string' && schema.shape[varName].description) {
+			description = `\n\r - ${schema.shape[varName].description}`;
+		}
 		// parsing succeeded
 		if (res.error === null && res.data !== '' && res.data !== 'undefined') {
 			const varValue = logVars
@@ -72,13 +77,13 @@ function logParseResults(
 		// no data, but parsing did not fail and the variable is optional
 		else if (res.error === null && res.optional) {
 			console.log(
-				`${WARN_SYMBOL} ${varName} ${WARN_COLOR}'${res.data}'${RESET_COLOR}`
+ 				`${WARN_SYMBOL} ${varName} ${WARN_COLOR}'${res.data}'${RESET_COLOR}${description}`
 			);
 		}
 		// parsing failed
 		else {
 			console.error(
-				`${ERR_SYMBOL} ${varName}: ${ERR_COLOR}${res.error}${RESET_COLOR}`
+				`${ERR_SYMBOL} ${varName}: ${ERR_COLOR}${res.error}${RESET_COLOR}${description}`
 			);
 			error_count++;
 		}

--- a/src/logParseResults.ts
+++ b/src/logParseResults.ts
@@ -64,7 +64,7 @@ function logParseResults(
 	Object.entries(schemaKeys).forEach(([varName, res]) => {
 		// Try to get the description from the Zod option if present
 		let description = '';
-		if (typeof schema.shape[varName]?.description === 'string' && schema.shape[varName].description) {
+		if (typeof schema.shape[varName]?.description === 'string') {
 			description = `\n\r - ${schema.shape[varName].description}`;
 		}
 		// parsing succeeded

--- a/src/logParseResults.ts
+++ b/src/logParseResults.ts
@@ -77,7 +77,7 @@ function logParseResults(
 		// no data, but parsing did not fail and the variable is optional
 		else if (res.error === null && res.optional) {
 			console.log(
- 				`${WARN_SYMBOL} ${varName} ${WARN_COLOR}'${res.data}'${RESET_COLOR}${description}`
+				`${WARN_SYMBOL} ${varName} ${WARN_COLOR}'${res.data}'${RESET_COLOR}${description}`
 			);
 		}
 		// parsing failed

--- a/src/schemaTypes.ts
+++ b/src/schemaTypes.ts
@@ -3,18 +3,19 @@ import {
 	enum as envEnum,
 	literal as envLiteral,
 	z,
+	RawCreateParams,
 } from 'zod';
 
-const nonEmpty = () =>
-	z.string().min(1, { message: 'Variable cannot be empty' });
+const nonEmpty = (params: RawCreateParams) =>
+	z.string(params).min(1, { message: 'Variable cannot be empty' });
 
-const envNonEmptyString = () =>
-	nonEmpty().refine((val) => val != 'undefined', {
+const envNonEmptyString = (params: RawCreateParams) =>
+	nonEmpty(params).refine((val) => val != 'undefined', {
 		message: `Variable cannot equal 'undefined'`,
 	});
 
-const envInteger = () =>
-	nonEmpty().regex(/^-?\d+$/, {
+const envInteger = (params: RawCreateParams) =>
+	nonEmpty(params).regex(/^-?\d+$/, {
 		message: 'Variable must be a valid integer',
 	});
 

--- a/src/schemaTypes.ts
+++ b/src/schemaTypes.ts
@@ -6,15 +6,15 @@ import {
 	RawCreateParams,
 } from 'zod';
 
-const nonEmpty = (params: RawCreateParams) =>
+const nonEmpty = (params?: RawCreateParams) =>
 	z.string(params).min(1, { message: 'Variable cannot be empty' });
 
-const envNonEmptyString = (params: RawCreateParams) =>
+const envNonEmptyString = (params?: RawCreateParams) =>
 	nonEmpty(params).refine((val) => val != 'undefined', {
 		message: `Variable cannot equal 'undefined'`,
 	});
 
-const envInteger = (params: RawCreateParams) =>
+const envInteger = (params?: RawCreateParams) =>
 	nonEmpty(params).regex(/^-?\d+$/, {
 		message: 'Variable must be a valid integer',
 	});


### PR DESCRIPTION
Adds functionality to display the description of a Zod schema property when a validation warning or error occurs. This helps users understand the meaning of environment variables and why they might be failing validation.

<img width="626" height="74" alt="image" src="https://github.com/user-attachments/assets/d133884d-9e98-44d3-8675-a5b6f098b0c9" />
<img width="634" height="200" alt="image" src="https://github.com/user-attachments/assets/e0720830-e16c-449f-8437-b4ae4339e9ab" />

